### PR TITLE
ACF pro get field collision fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 # woocommerce
 
+Notes:
+https://zapltd.slack.com/archives/C01TR8CANLU/p1750761818024279
+
 After downloading the DNA Payments WooCommerce plugin from GitHub, it would be advisable to rename the zip file to "wc-dnapayments.zip" before uploading and installing it.
+
+
+This is the fix for the draft orders issue that DNA didn't let us release!
+The updated plugin is called "WooCommerce DNA Payments Gateway by Zap" and the version is 3.0.15_ZAP
+Note, before updating, load this page /wp-admin/admin.php?page=wc-settings&tab=checkout&section=dnapayments and  verify the settings match after updating the plugin

--- a/includes/WC_DNA_Payments_Gateway.php
+++ b/includes/WC_DNA_Payments_Gateway.php
@@ -688,6 +688,26 @@ class WC_DNA_Payments_Gateway extends WC_Payment_Gateway {
         return $response;
     }
 
+	private function get_field($meta, $field) {
+		if ( isset( $meta [ $field ] ) ) {
+			return $meta [ $field ][0];
+		}
+		return '';
+	}
+
+	private function get_address($meta, $prefix) {
+		return array(
+			'firstName'     => $this->get_field( $meta, $prefix . '_first_name' ),
+			'lastName'      => $this->get_field( $meta, $prefix . '_last_name' ),
+			'addressLine1'  => $this->get_field( $meta, $prefix . '_address_1' ),
+			'addressLine2'  => $this->get_field( $meta, $prefix . '_address_2' ),
+			'city'          => $this->get_field( $meta, $prefix . '_city' ),
+			'postalCode'    => $this->get_field( $meta, $prefix . '_postcode' ),
+			'phone'         => $this->get_field( $meta, $prefix . '_phone' ),
+			'country'       => $this->get_field( $meta, $prefix . '_country' ),
+		);
+	}
+
     public function add_card_payment_data() {
 
         $user_id    = get_current_user_id();
@@ -700,25 +720,9 @@ class WC_DNA_Payments_Gateway extends WC_Payment_Gateway {
             return get_site_url( null, add_query_arg( array('result' => $result), 'my-account/payment-methods' ) );
         }
 
-        function get_field($meta, $field) {
-            if ( isset( $meta [ $field ] ) ) {
-                return $meta [ $field ][0];
-            }
-            return '';
-        }
 
-        function get_address($meta, $prefix) {
-            return array(
-                'firstName'     => get_field( $meta, $prefix . '_first_name' ),
-                'lastName'      => get_field( $meta, $prefix . '_last_name' ),
-                'addressLine1'  => get_field( $meta, $prefix . '_address_1' ),
-                'addressLine2'  => get_field( $meta, $prefix . '_address_2' ),
-                'city'          => get_field( $meta, $prefix . '_city' ),
-                'postalCode'    => get_field( $meta, $prefix . '_postcode' ),
-                'phone'         => get_field( $meta, $prefix . '_phone' ),
-                'country'       => get_field( $meta, $prefix . '_country' ),
-            );
-        }
+
+
 
         $paymentData = [
             'transactionType'   => 'VERIFICATION',
@@ -734,13 +738,13 @@ class WC_DNA_Payments_Gateway extends WC_Payment_Gateway {
                 'callbackUrl'       => get_rest_url(null, 'dnapayments/success-add-card')
             ],
             'customerDetails' => [
-                'email'             => get_field( $meta, 'billing_email' ),
+                'email'             => $this->get_field( $meta, 'billing_email' ),
                 'accountDetails' => [
                     'accountId'     => strval($user_id)
                 ],
-                'billingAddress'    => get_address($meta, 'billing'),
+                'billingAddress'    => $this->get_address($meta, 'billing'),
                 'deliveryDetails' => [
-                    'deliveryAddress' => get_address($meta, 'shipping'),
+                    'deliveryAddress' => $this->get_address($meta, 'shipping'),
                 ]
             ]
         ];

--- a/includes/WC_DNA_Payments_Gateway.php
+++ b/includes/WC_DNA_Payments_Gateway.php
@@ -82,7 +82,7 @@ class WC_DNA_Payments_Gateway extends WC_Payment_Gateway {
         $this->supports = array( 'products', 'refunds' );
         if ( $this->enabled_saved_cards ) {
             array_push($this->supports, 'tokenization' );
-        }        
+        }
     }
 
     public function get_config() {
@@ -303,17 +303,17 @@ class WC_DNA_Payments_Gateway extends WC_Payment_Gateway {
             if (!$order) {
                 throw new Exception('Order not found for ID: ' . $orderId, 400);
             }
-    
+
             $status = $order->get_status();
             $new_status = 'processing';
-    
+
             $logger->info('Processing success webhook for order ID ' . $orderId . ' with status ' . $status, ['source' => $log_source]);
-    
+
             // Validate order
             if (!WC_DNA_Payments_Order_Client_Helpers::isDNAPaymentOrder($order)) {
                 throw new Exception('Order processed by a different payment method: ' . $order->get_payment_method(), 400);
             }
-    
+
             if (!in_array($status, ['pending', 'failed', 'cancelled', 'on-hold'])) {
                 if (!empty($input['paypalCaptureStatus'])) {
                     $this->savePayPalOrderDetail($order, $input, true);
@@ -337,32 +337,32 @@ class WC_DNA_Payments_Gateway extends WC_Payment_Gateway {
                 $new_status = 'on-hold';
                 if ($status !== 'on-hold') {
                     $order->update_status('on-hold');
-                    $order->add_order_note(sprintf(__('DNA Payments awaiting payment completion (Transaction ID: %s)', 'woocommerce-gateway-dna'), $input['id'])); 
+                    $order->add_order_note(sprintf(__('DNA Payments awaiting payment completion (Transaction ID: %s)', 'woocommerce-gateway-dna'), $input['id']));
                 }
             }
 
             // Log status change
             $order->add_order_note(sprintf(__('DNA Payments updated order status from %s to %s.', 'woocommerce-gateway-dna'), ucfirst($status), ucfirst($new_status)));
-    
+
             // Update metadata
             $order->update_meta_data('rrn', $input['rrn'] ?? '');
             $order->update_meta_data('payment_method', $input['paymentMethod'] ?? '');
             $order->update_meta_data('is_finished_payment', $input['settled'] ? 'yes' : 'no');
-    
+
             if (!empty($input['paypalCaptureStatus'])) {
                 $this->savePayPalOrderDetail($order, $input, false);
             }
-    
+
             // Handle stock reduction
             $manage_stock_option = get_option('woocommerce_manage_stock');
             if ($manage_stock_option !== 'yes' || !in_array($status, ['pending', 'on-hold'])) {
                 wc_reduce_stock_levels($orderId);
                 $order->add_order_note(sprintf(__('DNA Payments reduced order stock (Transaction ID: %s)', 'woocommerce-gateway-dna'), $input['id']));
             }
-    
+
             $order->save();
             $logger->info('Processed success webhook for order ID ' . $orderId . ' with status ' . $status, ['source' => $log_source]);
-    
+
             // Handle saving card tokens
             if ($this->enabled_saved_cards && ($order->get_meta('save_payment_method_requested', true) === 'yes' || $input['storeCardOnFile'] || $storeCardOnFile)) {
                 WC_DNA_Payments_Order_Client_Helpers::saveCardToken($input, $this->id);
@@ -377,7 +377,7 @@ class WC_DNA_Payments_Gateway extends WC_Payment_Gateway {
             $logger->error('Error in success_webhook: ' . $e->getMessage(), ['source' => $log_source]);
             $logger->error('Input: ' . json_encode($data), ['source' => $log_source]);
             $logger->error('Stack trace: ' . $e->getTraceAsString(), ['source' => $log_source]);
-            
+
             // Respond with the error message and code
             return new WP_Error(
                 $this->id . '_error',
@@ -443,14 +443,14 @@ class WC_DNA_Payments_Gateway extends WC_Payment_Gateway {
             if(!empty($input['paypalCaptureStatus'])) {
                 $this->savePayPalOrderDetail($order, $input, false);
             }
-            
+
             if ($order->get_status() !== 'pending') {
                 throw new Exception('Order with ID ' . $orderId . ' is already processed with status: ' . $order->get_status(), 400);
             }
 
             $order->update_status('failed', 'Payment failed');
             $order->save();
-        
+
             return rest_ensure_response([
                 'success' => true,
                 'message' => 'Failure webhook processed successfully.',
@@ -459,7 +459,7 @@ class WC_DNA_Payments_Gateway extends WC_Payment_Gateway {
             $logger->error('Error in fail_webhook: ' . $e->getMessage(), ['source' => $log_source]);
             $logger->error('Input: ' . json_encode($data), ['source' => $log_source]);
             $logger->error('Stack trace: ' . $e->getTraceAsString(), ['source' => $log_source]);
-            
+
             // Respond with the error message and code
             return new WP_Error(
                 $this->id . '_error',
@@ -502,7 +502,7 @@ class WC_DNA_Payments_Gateway extends WC_Payment_Gateway {
             $logger->error('Error in success_webhook_add_card: ' . $e->getMessage(), ['source' => $log_source]);
             $logger->error('Input: ' . json_encode($data), ['source' => $log_source]);
             $logger->error('Stack trace: ' . $e->getTraceAsString(), ['source' => $log_source]);
-            
+
             // Respond with the error message and code
             return new WP_Error(
                 $this->id . '_error',
@@ -553,7 +553,7 @@ class WC_DNA_Payments_Gateway extends WC_Payment_Gateway {
         wp_register_script( 'dna-hosted-fields', 'https://' . $prefix . 'cdn.dnapayments.com/js/hosted-fields/hosted-fields.js' , array(), WC_DNA_VERSION, true );
         wp_register_script( 'dna-google-pay', 'https://' . $prefix . 'pay.dnapayments.com/components/google-pay/google-pay-component.js', array('dna-payment-api'), WC_DNA_VERSION, true );
         wp_register_script( 'dna-apple-pay', 'https://' . $prefix . 'pay.dnapayments.com/components/apple-pay/apple-pay-component.js', array('dna-payment-api'), WC_DNA_VERSION, true );
-        
+
         if ( ! is_cart() && ! is_checkout() && ! isset( $_GET['pay_for_order'] ) && ! is_add_payment_method_page()) {
             return;
         }
@@ -574,7 +574,7 @@ class WC_DNA_Payments_Gateway extends WC_Payment_Gateway {
             wp_register_script('woocommerce_dna_payment', plugins_url('assets/js/dna-add-payment-method.js', WC_DNA_MAIN_FILE), array('jquery', 'dna-payment-api', 'dna-hosted-fields') , WC_DNA_VERSION, true);
 
             $dna_params = $this->get_settings_for_frontend();
-        } else {            
+        } else {
             wp_register_script('woocommerce_dna_payment', plugins_url('assets/js/dna-payment.js', WC_DNA_MAIN_FILE), array('jquery', 'dna-hosted-fields', 'dna-google-pay', 'dna-apple-pay', 'dna-payment-api') , WC_DNA_VERSION, true);
 
             $dna_params = array_merge(
@@ -584,7 +584,7 @@ class WC_DNA_Payments_Gateway extends WC_Payment_Gateway {
                 ),
                 $this->get_settings_for_frontend()
             );
-        }        
+        }
 
         wp_localize_script( 'woocommerce_dna_payment', 'wc_dna_params', apply_filters( 'wc_dna_params', $dna_params ) );
         wp_enqueue_script('woocommerce_dna_payment');
@@ -597,7 +597,7 @@ class WC_DNA_Payments_Gateway extends WC_Payment_Gateway {
             // Skip validation on Pay for Order page
             return true;
         }
-        
+
         if( strlen ( $_POST[ 'billing_country' ]) > 2 ) {
             $this->add_notice(__('Country must be less than 2 symbols', 'woocommerce-gateway-dna' ), 'error');
             return false;
@@ -662,7 +662,7 @@ class WC_DNA_Payments_Gateway extends WC_Payment_Gateway {
             if ( $duplicate_order_id && $duplicate_order_id !== intval( $order_id ) ) {
                 $duplicate_order = wc_get_order( $duplicate_order_id );
                 if ( $duplicate_order && 'pending' === $duplicate_order->get_status() ) {
-                    $duplicate_order->update_status( 'checkout-draft', 'Order was cancelled by ' . $this->id . ' to prevent duplication.' );
+	                $duplicate_order->update_status( 'cancelled', 'Order was cancelled by ' . $this->id . ' to prevent duplication.' );
                     wc_release_stock_for_order( $duplicate_order_id );
                     $logger->info('Order with ID ' . $duplicate_order_id . ' was cancelled by ' . $this->id . ' to prevent duplication.', ['source' => $log_source]);
                 }
@@ -682,7 +682,7 @@ class WC_DNA_Payments_Gateway extends WC_Payment_Gateway {
             $response['auth'] = json_encode($response['auth']);
 
             $order->update_meta_data('save_payment_method_requested', $this->save_payment_method_requested() ? 'yes' : 'no');
-            $order->save();    
+            $order->save();
         }
 
         return $response;
@@ -716,7 +716,7 @@ class WC_DNA_Payments_Gateway extends WC_Payment_Gateway {
                 'city'          => get_field( $meta, $prefix . '_city' ),
                 'postalCode'    => get_field( $meta, $prefix . '_postcode' ),
                 'phone'         => get_field( $meta, $prefix . '_phone' ),
-                'country'       => get_field( $meta, $prefix . '_country' ), 
+                'country'       => get_field( $meta, $prefix . '_country' ),
             );
         }
 
@@ -746,7 +746,7 @@ class WC_DNA_Payments_Gateway extends WC_Payment_Gateway {
         ];
 
         echo json_encode(array(
-            'paymentData'   => $paymentData,            
+            'paymentData'   => $paymentData,
             'auth'          => $auth,
             'result'        => is_null($auth['access_token']) ? 'failure' : 'success'
         ));

--- a/woocommerce-gateway-dnapayments.php
+++ b/woocommerce-gateway-dnapayments.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce DNA Payments Gateway by Zap
  * Plugin URI: https://www.dnapayments.com
  * Description: Take credit card payments on your store.
- * Version: 3.0.15_ZAP
+ * Version: 3.0.16_ZAP
  *
  * Author: DNA Payments Integration
  * Author URI: https://www.dnapayments.com

--- a/woocommerce-gateway-dnapayments.php
+++ b/woocommerce-gateway-dnapayments.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Plugin Name: WooCommerce DNA Payments Gateway
+ * Plugin Name: WooCommerce DNA Payments Gateway by Zap
  * Plugin URI: https://www.dnapayments.com
  * Description: Take credit card payments on your store.
- * Version: 3.0.14
+ * Version: 3.0.15_ZAP
  *
  * Author: DNA Payments Integration
  * Author URI: https://www.dnapayments.com
@@ -67,9 +67,9 @@ class WC_DNA_Payments {
 		add_action( 'init', function() {
 			// Load translations
 			load_plugin_textdomain( self::$text_domain, false, self::plugin_abspath() . '/languages' );
-		} );		
+		} );
 
-		// This hook is used to execute code after all active plugins have fully loaded, 
+		// This hook is used to execute code after all active plugins have fully loaded,
 		// ensuring that WooCommerce is loaded before executing WooCommerce-specific code.
 		add_action( 'plugins_loaded', array( __CLASS__, 'includes' ), 0 );
 
@@ -85,12 +85,12 @@ class WC_DNA_Payments {
 		// Change "Thank you" ("Order received") page title when order status failed
 		add_filter( 'woocommerce_endpoint_order-received_title', array( __CLASS__, 'custom_woocommerce_endpoint_order_received_title' ), 10, 3 );
 
-		// Change "Thank you" ("Order received") page text when order status failed		
-		add_filter('woocommerce_thankyou_order_received_text', array( __CLASS__, 'custom_order_received_text' ), 10, 3);		
+		// Change "Thank you" ("Order received") page text when order status failed
+		add_filter('woocommerce_thankyou_order_received_text', array( __CLASS__, 'custom_order_received_text' ), 10, 3);
 	}
 
 	public static function before_woocommerce_hpos() {
-		if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) { 
+		if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
 			\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
 		}
 	}
@@ -99,7 +99,7 @@ class WC_DNA_Payments {
 		if ($endpoint == 'order-received') {
 			global $wp;
 
-			// Order status is sent via query string because the user might be redirected to the thank you page before the status is updated in the database. 
+			// Order status is sent via query string because the user might be redirected to the thank you page before the status is updated in the database.
 			$status = isset($_GET['status']) ? sanitize_text_field($_GET['status']) : '';
 			$order_id  = apply_filters( 'woocommerce_thankyou_order_id', absint( $wp->query_vars['order-received'] ) );
 


### PR DESCRIPTION
The add_card_payment_data method contains a nested function called `get_field`  that collides with ACF's global `get_field`. This causes /my-account/add-payment-method/ to fail when clicking the button

This PR moved get_field into the class as a method 